### PR TITLE
Layout rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Tilemap editor for SNES backgrounds
 
+# Install
+
+Make sure GTK+ libraries are installed, then go to [Releases](https://github.com/starliteSeeker/waffle/releases) and download the newest version.
+
+Only the linux version is provided because that's the only one I can test.
+
 # Build
 
 ~~works on my machine~~ 
@@ -23,4 +29,5 @@ Not much. If I ever feel like it, some important/quality-of-life features to add
 - 4bpp backgrounds
 - select mode on tilemap
 - different import/export file formats
+- layout resposive to window resize
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Tilemap editor for SNES backgrounds
 
+![waffle](https://github.com/user-attachments/assets/5cb83f3d-8f57-4806-8d05-7fe6353194f8)
+
 # Install
 
 Make sure GTK+ libraries are installed, then go to [Releases](https://github.com/starliteSeeker/waffle/releases) and download the newest version.

--- a/resources/gtk/color_picker.ui
+++ b/resources/gtk/color_picker.ui
@@ -13,15 +13,11 @@
     <child>
       <object class="GtkBox" id="color_sliders">
         <property name="orientation">vertical</property>
-        <property name="margin-start">10</property>
-        <property name="margin-end">10</property>
-        <property name="margin-top">10</property>
-        <property name="margin-bottom">10</property>
 
         <child>
           <object class="GtkScale" id="red_slider">
             <property name="orientation">horizontal</property>
-            <property name="width-request">300</property>
+            <property name="hexpand">true</property>
             <property name="draw-value">true</property>
             <property name="value-pos">right</property>
             <property name="digits">0</property>
@@ -42,7 +38,7 @@
         <child>
           <object class="GtkScale" id="green_slider">
             <property name="orientation">horizontal</property>
-            <property name="width-request">300</property>
+            <property name="hexpand">true</property>
             <property name="draw-value">true</property>
             <property name="value-pos">right</property>
             <property name="digits">0</property>
@@ -63,7 +59,7 @@
         <child>
           <object class="GtkScale" id="blue_slider">
             <property name="orientation">horizontal</property>
-            <property name="width-request">300</property>
+            <property name="hexpand">true</property>
             <property name="draw-value">true</property>
             <property name="value-pos">right</property>
             <property name="digits">0</property>

--- a/resources/gtk/palette_picker.ui
+++ b/resources/gtk/palette_picker.ui
@@ -6,7 +6,7 @@
     <child>
       <object class="GtkScrolledWindow" id="palette_scroll">
         <property name="propagate-natural-width">true</property>
-        <property name="min-content-height">192</property>
+        <property name="min-content-height">72</property>
         <property name="max-content-height">192</property>
         <child>
           <object class="GtkDrawingArea" id="palette_drawing">

--- a/resources/gtk/palette_picker.ui
+++ b/resources/gtk/palette_picker.ui
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <template class="PalettePicker" parent="GtkBox">
-    <property name="margin-start">10</property>
-    <property name="margin-end">10</property>
-    <property name="margin-top">10</property>
-    <property name="margin-bottom">10</property>
     <property name="orientation">vertical</property>
     <property name="halign">center</property>
     <child>

--- a/resources/gtk/tile_picker.ui
+++ b/resources/gtk/tile_picker.ui
@@ -2,6 +2,7 @@
 <interface>
   <template class="TilePicker" parent="GtkBox">
     <property name="orientation">vertical</property>
+    <property name="halign">center</property>
     <child>
       <object class="GtkBox">
         <property name="orientation">horizontal</property>
@@ -9,6 +10,7 @@
           <object class="GtkDrawingArea" id="tile_drawing">
             <property name="content-width">384</property>
             <property name="content-height">384</property>
+            <property name="valign">start</property>
           </object>
         </child>
         <child>

--- a/resources/gtk/tilemap_editor.ui
+++ b/resources/gtk/tilemap_editor.ui
@@ -6,8 +6,8 @@
       <object class="GtkScrolledWindow" id="tilemap_scroll">
         <property name="propagate-natural-width">true</property>
         <property name="propagate-natural-height">true</property>
-        <property name="max-content-width">768</property>
-        <property name="max-content-height">768</property>
+        <property name="max-content-width">640</property>
+        <property name="max-content-height">640</property>
         <child>
           <object class="GtkDrawingArea" id="tilemap_drawing">
             <property name="content-width">768</property>


### PR DESCRIPTION
The original plan was to resize widgets based on window size, but that didn't work out for several reasons:

- `ConstraintLayout` doesn't work well with `ScrolledWindow`. After resizing the window and interacting with the scroll, the window can no longer be resized smaller.
- Drawing pixels with fractional size creates "cracks" within and between tiles. Looks awful.

So I ended up just resizing the UI to be smaller, since it's better to have small UI than to have the window go out of the screen.