### PR TITLE
Remove filesize limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ data 22222222 33333333 22222222 ... 22222222 33333333 ...
 
 An example of this format can be found [here](examples/tilemap.bin).
 
-The file size is always 2048 bytes. Each tilemap tile takes up 2 bytes, and tiles are arranged as a 32-by-32 square.
+The file size is usually 2048 bytes. Each tilemap tile takes up 2 bytes, and tiles are arranged as a 32-by-32 square. For convenience, files storing less than 32x32 tiles are also accepted.
 
 ```text
 tile                 0 ...

--- a/src/data/tilemap.rs
+++ b/src/data/tilemap.rs
@@ -1,10 +1,8 @@
 use std::cell::RefCell;
 use std::fs::File;
 use std::io::Write;
-use std::mem::{self, MaybeUninit};
 use std::rc::Rc;
 
-use itertools::Itertools;
 use modular_bitfield::prelude::*;
 
 use crate::data::list_items::{BGMode, TileSize};
@@ -22,12 +20,12 @@ pub struct Tile {
 }
 
 pub struct Tilemap {
-    tiles: [Tile; 32 * 32],
+    tiles: Vec<Tile>,
 }
 
 impl Default for Tilemap {
     fn default() -> Self {
-        let arr = [Tile::new(); 32 * 32];
+        let arr = vec![Tile::new(); 32 * 32];
         Tilemap { tiles: arr }
     }
 }
@@ -36,31 +34,34 @@ impl Tilemap {
     pub fn from_path(path: &std::path::PathBuf) -> std::io::Result<Self> {
         let content = std::fs::read(&path)?;
         let len = content.len();
-        if len != 32 * 32 * 2 {
+        // check alignment
+        if len % 2 != 0 {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
-                "file must be 2048 bytes",
+                format!("file size is {} but should be a multiple of 2", len),
+            ));
+        }
+        // check file size
+        if len > 32 * 32 * 2 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "file must not exceed 2048 bytes",
             ));
         }
 
-        // unsafe initializing array
-        // https://doc.rust-lang.org/core/mem/union.MaybeUninit.html#initializing-an-array-element-by-element
         Ok(Tilemap {
             tiles: {
-                let mut data: [MaybeUninit<Tile>; 32 * 32] =
-                    unsafe { MaybeUninit::uninit().assume_init() };
-
-                for (i, (lo, hi)) in content.into_iter().tuples().enumerate() {
-                    data[i].write(Tile::from_bytes([lo, hi]));
+                let mut v = Vec::with_capacity(len / 2);
+                for i in (0..len).step_by(2) {
+                    v.push(Tile::from_bytes([content[i], content[i + 1]]));
                 }
-
-                unsafe { mem::transmute::<_, [Tile; 32 * 32]>(data) }
+                v
             },
         })
     }
 
     pub fn write_to_file(&self, mut f: &File) -> std::io::Result<()> {
-        for c in self.tiles {
+        for c in &self.tiles {
             f.write_all(&c.into_bytes())?;
         }
         Ok(())
@@ -68,7 +69,7 @@ impl Tilemap {
 
     // return true if new tile is different from old one
     pub fn set_tile(&mut self, idx: u32, tile: &Tile) -> bool {
-        if idx >= 32 * 32 {
+        if idx >= self.tiles.len() as u32 {
             return false;
         }
         if self.tiles[idx as usize] == *tile {
@@ -87,13 +88,12 @@ impl Tilemap {
         bg_mode: Rc<RefCell<BGMode>>,
         tile_size: Rc<RefCell<TileSize>>,
     ) {
-        // default color
-        cr.set_source_rgb(0.0, 1.0, 1.0);
+        cr.set_source_rgb(0.4, 0.4, 0.4);
         let _ = cr.paint();
 
         let bg_mode = bg_mode.borrow();
 
-        for (i, tile) in self.tiles.into_iter().enumerate() {
+        for (i, tile) in self.tiles.iter().enumerate() {
             let x_offset = (i % 32) as f64 * crate::TILE_W;
             let y_offset = (i / 32) as f64 * crate::TILE_W;
 

--- a/src/data/tilemap.rs
+++ b/src/data/tilemap.rs
@@ -1,4 +1,6 @@
 use std::cell::RefCell;
+use std::fs::File;
+use std::io::Write;
 use std::mem::{self, MaybeUninit};
 use std::rc::Rc;
 
@@ -20,7 +22,7 @@ pub struct Tile {
 }
 
 pub struct Tilemap {
-    pub tiles: [Tile; 32 * 32],
+    tiles: [Tile; 32 * 32],
 }
 
 impl Default for Tilemap {
@@ -55,6 +57,13 @@ impl Tilemap {
                 unsafe { mem::transmute::<_, [Tile; 32 * 32]>(data) }
             },
         })
+    }
+
+    pub fn write_to_file(&self, mut f: &File) -> std::io::Result<()> {
+        for c in self.tiles {
+            f.write_all(&c.into_bytes())?;
+        }
+        Ok(())
     }
 
     // return true if new tile is different from old one

--- a/src/widgets/tilemap_editor/mod.rs
+++ b/src/widgets/tilemap_editor/mod.rs
@@ -2,7 +2,6 @@ mod imp;
 
 use std::cell::RefCell;
 use std::fs::File;
-use std::io::Write;
 use std::path::PathBuf;
 use std::rc::Rc;
 
@@ -174,10 +173,8 @@ impl TilemapEditor {
                 let Some(filepath) = this.file() else {return};
                 println!("save tilemap: {filepath:?}");
                 match File::create(filepath) {
-                    Ok(mut f) => {
-                        for c in this.imp().map_data.borrow().tiles {
-                            let _ = f.write_all(&c.into_bytes());
-                        }
+                    Ok(f) => {
+                        let _ = this.imp().map_data.borrow().write_to_file(&f);
                     },
                     Err(e) => eprintln!("Error saving file: {e}"),
                 }
@@ -189,10 +186,8 @@ impl TilemapEditor {
                 file_save_dialog(parent, move |_, filepath| {
                     println!("save tilemap: {filepath:?}");
                     match File::create(filepath.clone()) {
-                        Ok(mut f) => {
-                            for c in this.imp().map_data.borrow().tiles {
-                                let _ = f.write_all(&c.into_bytes());
-                            }
+                        Ok(f) => {
+                            let _ = this.imp().map_data.borrow().write_to_file(&f);
                             this.set_file(Some(filepath));
                         },
                         Err(e) => eprintln!("Error saving file: {e}"),

--- a/src/widgets/tilemap_editor/mod.rs
+++ b/src/widgets/tilemap_editor/mod.rs
@@ -80,6 +80,7 @@ impl TilemapEditor {
             }),
         );
     }
+
     fn setup_signal_connection<P: WidgetExt, T: WidgetExt>(&self, palette_obj: P, tile_obj: T) {
         palette_obj.connect_closure(
             "palette-changed",


### PR DESCRIPTION
Sometimes files are truncated to save space, but I still want to be able to open them.